### PR TITLE
Add help overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,16 +5,41 @@
     html {
       background: #000;
     }
+    #help-overlay {
+      position: absolute;
+      left: 0;
+      top: 0;
+      padding: 5px 10px;
+      background: rgba(0,0,0,0.7);
+      color: #0f0;
+      font-family: monospace;
+      font-size: 12px;
+    }
+    #help-overlay.hidden { display: none; }
     </style>
     <meta charset="utf-8">
     <title></title>
   </head>
 
   <body>
-    <canvas>
-      </canvas>
-      <script src="./point3d.js"></script>
-      <script src="./canvas3d.js"></script>
-      <script src="./main.js"></script>
+    <canvas></canvas>
+    <div id="help-overlay">
+      <div>
+        <strong>Controls</strong><br>
+        Arrow Keys: move camera<br>
+        A/Z: move camera depth<br>
+        X/S: zoom out/in<br>
+        Q/W/E: toggle rotation X/Y/Z<br>
+        R: hardware lines<br>
+        M: toggle stats<br>
+        F/V: add/remove points<br>
+        B: batch points<br>
+        O: occlusion<br>
+        H: hide help
+      </div>
+    </div>
+    <script src="./point3d.js"></script>
+    <script src="./canvas3d.js"></script>
+    <script src="./main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -12,6 +12,16 @@ let previousTimestamp = null;
 let enableStats = false;
 let enableBatchPoints = false;
 let enableOcclusion = false;
+const helpOverlay = document.getElementById('help-overlay');
+let helpVisible = true;
+const toggleHelp = () => {
+  helpVisible = !helpVisible;
+  if (helpVisible) {
+    helpOverlay.classList.remove('hidden');
+  } else {
+    helpOverlay.classList.add('hidden');
+  }
+};
 window.C3D.cameraPoint.translate(0,0,-10)
 
 window.addEventListener('keydown', (e) => {
@@ -55,6 +65,8 @@ window.addEventListener('keydown', (e) => {
     enableBatchPoints = !enableBatchPoints;
   } else if (e.code == 'KeyO') {
     enableOcclusion =  !enableOcclusion;
+  } else if (e.code == 'KeyH') {
+    toggleHelp();
   }
 });
 
@@ -85,7 +97,7 @@ try {
     showStats: enableStats,
     texts: [
       {
-        text: 'Press: QWERAZSXVFBMO',
+        text: 'Press H for help',
         x: 0,
         y: 390
       }


### PR DESCRIPTION
## Summary
- show an always visible help overlay
- allow toggling the overlay with `H`
- update the hint text at the bottom

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684537a5c67083228e82be0380f98a68