### PR TITLE
Improve stats overlay UI

### DIFF
--- a/canvas3d.js
+++ b/canvas3d.js
@@ -212,6 +212,13 @@ class Canvas3D {
       i++;
     }
   }
+
+  getStats() {
+    return {
+      ...this.stats,
+      ...this.settings
+    };
+  }
   drawTexts(texts, clearScreen) {
     if (clearScreen)
       this.clearScreen();

--- a/index.html
+++ b/index.html
@@ -16,14 +16,26 @@
       font-size: 12px;
     }
     #help-overlay.hidden { display: none; }
+    #stats-overlay {
+      position: absolute;
+      right: 0;
+      top: 0;
+      padding: 5px 10px;
+      background: rgba(0,0,0,0.7);
+      color: #0f0;
+      font-family: monospace;
+      font-size: 12px;
+      text-align: right;
+    }
+    #stats-overlay.hidden { display: none; }
     </style>
     <meta charset="utf-8">
     <title></title>
   </head>
 
   <body>
-    <canvas></canvas>
-    <div id="help-overlay">
+  <canvas></canvas>
+  <div id="help-overlay">
       <div>
         <strong>Controls</strong><br>
         Arrow Keys: move camera<br>
@@ -37,9 +49,10 @@
         O: occlusion<br>
         H: hide help
       </div>
-    </div>
-    <script src="./point3d.js"></script>
-    <script src="./canvas3d.js"></script>
-    <script src="./main.js"></script>
+  </div>
+  <div id="stats-overlay" class="hidden"></div>
+  <script src="./point3d.js"></script>
+  <script src="./canvas3d.js"></script>
+  <script src="./main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -9,10 +9,11 @@ let enableRotateY = true;
 let enableRotateZ = false;
 let enableHWLineRen = false;
 let previousTimestamp = null;
-let enableStats = false;
+let statsVisible = false;
 let enableBatchPoints = false;
 let enableOcclusion = false;
 const helpOverlay = document.getElementById('help-overlay');
+const statsOverlay = document.getElementById('stats-overlay');
 let helpVisible = true;
 const toggleHelp = () => {
   helpVisible = !helpVisible;
@@ -20,6 +21,14 @@ const toggleHelp = () => {
     helpOverlay.classList.remove('hidden');
   } else {
     helpOverlay.classList.add('hidden');
+  }
+};
+const toggleStats = () => {
+  statsVisible = !statsVisible;
+  if (statsVisible) {
+    statsOverlay.classList.remove('hidden');
+  } else {
+    statsOverlay.classList.add('hidden');
   }
 };
 window.C3D.cameraPoint.translate(0,0,-10)
@@ -51,7 +60,7 @@ window.addEventListener('keydown', (e) => {
   } else if (e.code == 'KeyR') {
     enableHWLineRen = !enableHWLineRen;
   }  else if (e.code == 'KeyM') {
-    enableStats = !enableStats;
+    toggleStats();
   } else if (e.code == 'KeyF') {
     for (let i =0; i< 10; i++) {
       let point = new Point3D(0,0,0);
@@ -91,19 +100,25 @@ try {
   C3D.settings.batch = enableBatchPoints;
 
 
-  C3D.completeScreenDraw({
-    lines: cubeLines,
-    points: arr,
-    showStats: enableStats,
-    texts: [
+    C3D.completeScreenDraw({
+      lines: cubeLines,
+      points: arr,
+      showStats: false,
+      texts: [
       {
         text: 'Press H for help',
         x: 0,
         y: 390
       }
-    ]
-  })
-} catch(e) {
+      ]
+    })
+    if (statsVisible) {
+      const stats = C3D.getStats();
+      statsOverlay.innerHTML = Object.keys(stats)
+        .map(k => `${k}: ${stats[k]}`)
+        .join('<br>');
+    }
+  } catch(e) {
   console.warn(e);
   console.log('out of bounds')
 }


### PR DESCRIPTION
## Summary
- add stats overlay HTML and style
- add DOM-based stats update logic in main.js
- expose Canvas3D stats via `getStats`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684539c0b3508322bcb7feb6ef6febae