### PR TITLE
Move help hint into HTML element

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,17 @@
       text-align: right;
     }
     #stats-overlay.hidden { display: none; }
+    #press-hint {
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      padding: 5px 10px;
+      background: rgba(0,0,0,0.7);
+      color: #0f0;
+      font-family: monospace;
+      font-size: 12px;
+    }
+    #press-hint.hidden { display: none; }
     </style>
     <meta charset="utf-8">
     <title></title>
@@ -60,6 +71,7 @@
       </div>
   </div>
   <div id="stats-overlay" class="hidden"></div>
+  <div id="press-hint">Press H for help</div>
   <script src="./point3d.js"></script>
   <script src="./canvas3d.js"></script>
   <script src="./main.js"></script>

--- a/main.js
+++ b/main.js
@@ -31,6 +31,8 @@ let enableBatchPoints = false;
 let enableOcclusion = false;
 const helpOverlay = document.getElementById('help-overlay');
 const statsOverlay = document.getElementById('stats-overlay');
+const pressHint = document.getElementById('press-hint');
+pressHint.classList.add('hidden');
 let helpVisible = true;
 let mouseDown = false;
 let lastMouseX = 0;
@@ -40,8 +42,10 @@ const toggleHelp = () => {
   helpVisible = !helpVisible;
   if (helpVisible) {
     helpOverlay.classList.remove('hidden');
+    pressHint.classList.add('hidden');
   } else {
     helpOverlay.classList.add('hidden');
+    pressHint.classList.remove('hidden');
   }
 };
 const toggleStats = () => {
@@ -184,14 +188,7 @@ try {
     C3D.completeScreenDraw({
       lines: cubeLines,
       points: arr,
-      showStats: false,
-      texts: [
-      {
-        text: 'Press H for help',
-        x: 0,
-        y: C3D.height - 10
-      }
-      ]
+      showStats: false
     })
     if (statsVisible) {
       const stats = C3D.getStats();


### PR DESCRIPTION
## Summary
- add bottom-left help hint element instead of drawing text to the canvas
- toggle hint visibility when help overlay is shown/hidden

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845426ca66c8322b569c92d88fe9d4d