### PR TITLE
Add sword model toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,17 @@
       font-size: 12px;
     }
     #press-hint.hidden { display: none; }
+    #model-toggle {
+      position: absolute;
+      right: 10px;
+      bottom: 10px;
+      padding: 5px 10px;
+      background: rgba(0,0,0,0.7);
+      color: #0f0;
+      border: 1px solid #0f0;
+      font-family: monospace;
+      font-size: 12px;
+    }
     </style>
     <meta charset="utf-8">
     <title></title>
@@ -66,10 +77,11 @@
         O: occlusion<br>
         L: fullscreen<br>
         H: hide help<br>
-        Mouse drag: look around<br>
-        Mouse wheel: zoom in/out
-      </div>
+      Mouse drag: look around<br>
+      Mouse wheel: zoom in/out
+    </div>
   </div>
+  <button id="model-toggle">Show Sword</button>
   <div id="stats-overlay" class="hidden"></div>
   <div id="press-hint">Press H for help</div>
   <script src="./point3d.js"></script>

--- a/main.js
+++ b/main.js
@@ -32,6 +32,7 @@ let enableOcclusion = false;
 const helpOverlay = document.getElementById('help-overlay');
 const statsOverlay = document.getElementById('stats-overlay');
 const pressHint = document.getElementById('press-hint');
+const modelToggleBtn = document.getElementById('model-toggle');
 pressHint.classList.add('hidden');
 let helpVisible = true;
 let mouseDown = false;
@@ -186,7 +187,7 @@ try {
 
 
     C3D.completeScreenDraw({
-      lines: cubeLines,
+      lines: currentLines,
       points: arr,
       showStats: false
     })
@@ -248,9 +249,60 @@ let cubeLines = [
   [cubePoints[5], cubePoints[4]],
 ]
 
+let swordPoints = [];
+// define a simple sword model
+swordPoints.push(new Point3D(0, 3, 0));     // tip
+swordPoints.push(new Point3D(-0.2, 1, 0));  // left blade base
+swordPoints.push(new Point3D(0.2, 1, 0));   // right blade base
+swordPoints.push(new Point3D(-1, 0.8, 0));  // crossguard left end
+swordPoints.push(new Point3D(1, 0.8, 0));   // crossguard right end
+swordPoints.push(new Point3D(-0.2, 0, 0));  // handle left top
+swordPoints.push(new Point3D(0.2, 0, 0));   // handle right top
+swordPoints.push(new Point3D(-0.2, -1.5, 0)); // handle left bottom
+swordPoints.push(new Point3D(0.2, -1.5, 0));  // handle right bottom
+swordPoints.push(new Point3D(0, -1.7, 0));  // pommel
+
+let swordLines = [
+  [swordPoints[0], swordPoints[1]],
+  [swordPoints[0], swordPoints[2]],
+  [swordPoints[1], swordPoints[2]],
+  [swordPoints[1], swordPoints[3]],
+  [swordPoints[2], swordPoints[4]],
+  [swordPoints[3], swordPoints[4]],
+  [swordPoints[1], swordPoints[5]],
+  [swordPoints[2], swordPoints[6]],
+  [swordPoints[5], swordPoints[6]],
+  [swordPoints[5], swordPoints[7]],
+  [swordPoints[6], swordPoints[8]],
+  [swordPoints[7], swordPoints[8]],
+  [swordPoints[7], swordPoints[9]],
+  [swordPoints[8], swordPoints[9]],
+];
+
 for (let i =0; i < cubePoints.length; i++) {
   cubePoints[i].setColor('#f0f');
 }
+
+for (let i =0; i < swordPoints.length; i++) {
+  swordPoints[i].setColor('#0ff');
+}
+
+let currentLines = cubeLines;
+let currentModel = 'cube';
+
+const toggleModel = () => {
+  if (currentModel === 'cube') {
+    currentModel = 'sword';
+    currentLines = swordLines;
+    modelToggleBtn.textContent = 'Show Cube';
+  } else {
+    currentModel = 'cube';
+    currentLines = cubeLines;
+    modelToggleBtn.textContent = 'Show Sword';
+  }
+};
+
+modelToggleBtn.addEventListener('click', toggleModel);
 
 setInterval(updatePoints, 15);
 


### PR DESCRIPTION
## Summary
- add button to change between cube and sword models
- implement simple sword model vertex data in `main.js`
- handle toggle logic and button text updates
- style the new toggle button and include it in the page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684630cf27808322b7d119cc0f6f4e62