### PR TITLE
Add vertex size based on depth

### DIFF
--- a/canvas3d.js
+++ b/canvas3d.js
@@ -132,7 +132,9 @@ class Canvas3D {
     point.setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
     this.stats.drawnPoints ++;
     let p2d = point.getRotated2D(this.worldRotation, this.zoom);
-    this.fillRectWithScreenTest(Math.round(p2d.x), Math.round(p2d.y), 1, 1);
+    let size = point.getScale(this.worldRotation, this.zoom);
+    size = Math.max(1, size);
+    this.fillRectWithScreenTest(Math.round(p2d.x - size/2), Math.round(p2d.y - size/2), Math.round(size), Math.round(size));
   }
 
   fillRectWithScreenTest(x,y,w,h) {

--- a/point3d.js
+++ b/point3d.js
@@ -91,6 +91,15 @@ class Point3D {
     }
   }
 
+  getScale(worldRotation, zoom = 1) {
+    let rot = this.rotateAroundX(this.x, this.y, this.z, worldRotation.x);
+    rot = this.rotateAroundY(rot.x, rot.y, rot.z, worldRotation.y);
+    rot = this.rotateAroundZ(rot.x, rot.y, rot.z, worldRotation.z);
+    const denom = (rot.z + this.offsetZ) / zoom;
+    if (denom === 0) return 0;
+    return Math.abs(1 / denom);
+  }
+
   get2D (zoom = 1) {
     try {
       let rx = this.offsetX + (this.x / ((this.z + this.offsetZ)/zoom));


### PR DESCRIPTION
## Summary
- compute scale for a point based on its Z depth
- draw points using the calculated size so they grow as they approach the camera

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846365dc5b08322a04724bd96b4ddbe