### PR TITLE
Fix vertex scale based on camera distance

### DIFF
--- a/point3d.js
+++ b/point3d.js
@@ -95,9 +95,12 @@ class Point3D {
     let rot = this.rotateAroundX(this.x, this.y, this.z, worldRotation.x);
     rot = this.rotateAroundY(rot.x, rot.y, rot.z, worldRotation.y);
     rot = this.rotateAroundZ(rot.x, rot.y, rot.z, worldRotation.z);
-    const denom = (rot.z + this.offsetZ) / zoom;
-    if (denom === 0) return 0;
-    return Math.abs(1 / denom);
+    const dx = rot.x;
+    const dy = rot.y;
+    const dz = rot.z + this.offsetZ;
+    const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (distance === 0) return 0;
+    return zoom / distance;
   }
 
   get2D (zoom = 1) {


### PR DESCRIPTION
## Summary
- compute vertex scale using full 3D distance from the camera viewpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684637fa78448322893a6576b4864141