### PR TITLE
Sort primitives by camera distance

### DIFF
--- a/canvas3d.js
+++ b/canvas3d.js
@@ -51,14 +51,20 @@ class Canvas3D {
   }
 
   drawPoints(points, clearScreen) {
-    if(clearScreen)
+    if (clearScreen)
       this.clearScreen();
 
+    const sorted = [...points].sort((a, b) => {
+      a.setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
+      b.setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
+      return b.getDistanceFromCamera(this.worldRotation) - a.getDistanceFromCamera(this.worldRotation);
+    });
+
     if (this.settings.batch) {
-      this.drawBatchedPoints(points, clearScreen);
+      this.drawBatchedPoints(sorted, false);
     } else {
-      for (let i = 0; i < points.length; i++) {
-        this.drawPoint(points[i]);
+      for (let i = 0; i < sorted.length; i++) {
+        this.drawPoint(sorted[i]);
       }
     }
   }
@@ -89,8 +95,18 @@ class Canvas3D {
     if (clearScreen)
       this.clearScreen();
 
-    for (let i =0; i< lines.length; i++) {
-      this.drawLine(lines[i][0], lines[i][1]);
+    const sorted = [...lines].sort((a, b) => {
+      a[0].setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
+      a[1].setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
+      b[0].setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
+      b[1].setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
+      const distA = (a[0].getDistanceFromCamera(this.worldRotation) + a[1].getDistanceFromCamera(this.worldRotation)) / 2;
+      const distB = (b[0].getDistanceFromCamera(this.worldRotation) + b[1].getDistanceFromCamera(this.worldRotation)) / 2;
+      return distB - distA;
+    });
+
+    for (let i = 0; i < sorted.length; i++) {
+      this.drawLine(sorted[i][0], sorted[i][1]);
     }
   }
 

--- a/point3d.js
+++ b/point3d.js
@@ -103,6 +103,16 @@ class Point3D {
     return zoom / distance;
   }
 
+  getDistanceFromCamera(worldRotation) {
+    let rot = this.rotateAroundX(this.x, this.y, this.z, worldRotation.x);
+    rot = this.rotateAroundY(rot.x, rot.y, rot.z, worldRotation.y);
+    rot = this.rotateAroundZ(rot.x, rot.y, rot.z, worldRotation.z);
+    const dx = rot.x;
+    const dy = rot.y;
+    const dz = rot.z + this.offsetZ;
+    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+  }
+
   get2D (zoom = 1) {
     try {
       let rx = this.offsetX + (this.x / ((this.z + this.offsetZ)/zoom));


### PR DESCRIPTION
## Summary
- sort points and lines before drawing so closer objects render last
- expose `getDistanceFromCamera` helper on `Point3D`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68463991ae248322afff4df8f3b7e77c