### PR TITLE
Implement basic vertex occlusion

### DIFF
--- a/canvas3d.js
+++ b/canvas3d.js
@@ -115,6 +115,9 @@ class Canvas3D {
   drawLine(pointA, pointB) {
     pointA.setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
     pointB.setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
+    if (this.settings.occlusion && (pointA.isBehindCamera(this.worldRotation) || pointB.isBehindCamera(this.worldRotation))) {
+      return;
+    }
     let pA = pointA.getRotated2D(this.worldRotation, this.zoom);
     let pB = pointB.getRotated2D(this.worldRotation, this.zoom);
     this.stats.drawnLines ++;
@@ -148,6 +151,9 @@ class Canvas3D {
 
   drawPointNoColor(point) {
     point.setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
+    if (this.settings.occlusion && point.isBehindCamera(this.worldRotation)) {
+      return;
+    }
     this.stats.drawnPoints ++;
     let p2d = point.getRotated2D(this.worldRotation, this.zoom);
     let size = point.getScale(this.worldRotation, this.zoom) * this.pointSizeScale;

--- a/point3d.js
+++ b/point3d.js
@@ -70,6 +70,13 @@ class Point3D {
     }
   }
 
+  isBehindCamera(worldRotation) {
+    let rot = this.rotateAroundX(this.x, this.y, this.z, worldRotation.x);
+    rot = this.rotateAroundY(rot.x, rot.y, rot.z, worldRotation.y);
+    rot = this.rotateAroundZ(rot.x, rot.y, rot.z, worldRotation.z);
+    return (rot.z + this.offsetZ) > 0;
+  }
+
 
   getRotated2D (worldRotation, zoom = 1) {
     let rot = this.rotateAroundX(this.x, this.y, this.z, worldRotation.x);


### PR DESCRIPTION
## Summary
- skip rendering points that are behind the camera
- skip rendering lines if either vertex is behind the camera
- expose helper `isBehindCamera` on `Point3D`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68464a8a01f883229979ff9ca644ff6f