### PR TITLE
Ensure depth-sorted rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ It's made with plain new JS.
 - Touch drag to rotate the view.
 - Pinch to zoom in and out on touch screens.
 - Choose between several 3D models like sword, cube, sphere, star and the new pyramid.
+- Points and lines are now rendered in proper depth order.
 
 Check it here: [https://rokyed.github.io/canvas-dot/](https://rokyed.github.io/canvas-dot/)

--- a/canvas3d.js
+++ b/canvas3d.js
@@ -210,11 +210,34 @@ export default class Canvas3D {
   completeScreenDraw(obj = {}) {
     this.start();
     this.clearScreen();
-    if (obj.lines)
-      this.drawLines(obj.lines, false);
+    const hasPoints = Array.isArray(obj.points);
+    const hasLines = Array.isArray(obj.lines);
 
-    if (obj.points)
-      this.drawPoints(obj.points, false);
+    if (hasPoints && hasLines) {
+      const elements = [];
+      for (const [a, b] of obj.lines) {
+        a.setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
+        b.setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
+        const dist = (a.getDistanceFromCamera(this.worldRotation) +
+          b.getDistanceFromCamera(this.worldRotation)) / 2;
+        elements.push({ type: 'line', a, b, dist });
+      }
+      for (const p of obj.points) {
+        p.setOffset(this.cameraPoint.x, this.cameraPoint.y, this.cameraPoint.z);
+        const dist = p.getDistanceFromCamera(this.worldRotation);
+        elements.push({ type: 'point', p, dist });
+      }
+      elements.sort((x, y) => y.dist - x.dist);
+      for (const el of elements) {
+        if (el.type === 'line') this.drawLine(el.a, el.b);
+        else this.drawPoint(el.p);
+      }
+    } else {
+      if (hasLines)
+        this.drawLines(obj.lines, false);
+      if (hasPoints)
+        this.drawPoints(obj.points, false);
+    }
 
     if (obj.texts)
       this.drawTexts(obj.texts, false);


### PR DESCRIPTION
## Summary
- sort points and lines together when rendering
- document depth order in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684918cd5e6c8322a80b9cbaa01b5f6a