### PR TITLE
Add heart model

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It's made with plain new JS.
 - Mouse wheel to zoom in and out.
 - Touch drag to rotate the view.
 - Pinch to zoom in and out on touch screens.
-- Choose between several 3D models like sword, cube, sphere, star and the new pyramid.
+- Choose between several 3D models like sword, cube, sphere, star, pyramid and the new heart.
 - Points and lines are now rendered in proper depth order.
 - Objects behind the camera are never rendered.
 

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
     <option value="cube">Cube</option>
     <option value="sphere">Sphere</option>
     <option value="star">Star</option>
+    <option value="heart">Heart</option>
     <option value="pyramid">Pyramid</option>
     <option value="pendulum">Pendulum</option>
   </select>

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ import { createCube } from './models/cube.js';
 import { createSword } from './models/sword.js';
 import { createSphere } from './models/sphere.js';
 import { createStar } from './models/star.js';
+import { createHeart } from './models/heart.js';
 import { createPyramid } from './models/pyramid.js';
 import { createPendulum } from './models/pendulum.js';
 
@@ -309,6 +310,7 @@ const { points: spherePoints, lines: sphereLines } = createSphere(16, 16, 2);
 spherePoints.forEach(p => p.setColor('#ff0'));
 const { points: starPoints, lines: starLines } = createStar(5, 2, 1, 0.4);
 starPoints.forEach(p => p.setColor('#fa0'));
+const { points: heartPoints, lines: heartLines } = createHeart();
 const { points: pyramidPoints, lines: pyramidLines } = createPyramid(2, 2);
 const { points: pendulumPoints, lines: pendulumLines, update: updatePendulum } = createPendulum(4, 1);
 
@@ -322,6 +324,8 @@ const updateModel = () => {
     currentLines = sphereLines;
   } else if (value === 'star') {
     currentLines = starLines;
+  } else if (value === 'heart') {
+    currentLines = heartLines;
   } else if (value === 'pyramid') {
     currentLines = pyramidLines;
   } else if (value === 'pendulum') {

--- a/models/heart.js
+++ b/models/heart.js
@@ -1,0 +1,28 @@
+import Point3D from '../point3d.js';
+
+export function createHeart(steps = 60, scale = 0.2, thickness = 0.5) {
+  const base = [];
+  for (let i = 0; i < steps; i++) {
+    const t = (i / steps) * Math.PI * 2;
+    const x = 16 * Math.pow(Math.sin(t), 3);
+    const y = 13 * Math.cos(t) - 5 * Math.cos(2 * t) - 2 * Math.cos(3 * t) - Math.cos(4 * t);
+    base.push(new Point3D(x * scale, y * scale, 0));
+  }
+
+  const front = base.map(p => new Point3D(p.x, p.y, -thickness / 2));
+  const back = base.map(p => new Point3D(p.x, p.y, thickness / 2));
+  const points = [...front, ...back];
+  const lines = [];
+  const len = base.length;
+
+  for (let i = 0; i < len; i++) {
+    const next = (i + 1) % len;
+    lines.push([points[i], points[next]]);
+    lines.push([points[i + len], points[next + len]]);
+    lines.push([points[i], points[i + len]]);
+  }
+
+  points.forEach(p => p.setColor('#f00'));
+
+  return { points, lines };
+}


### PR DESCRIPTION
## Summary
- add heart shape model
- include heart option in dropdown
- load heart model in main script
- mention heart model in README

## Testing
- `node -c main.js`
- `node -e "import('./models/heart.js').then(m=>console.log('ok'))"`

------
https://chatgpt.com/codex/tasks/task_e_684b5b9c1d5083229482eb1f614e8baa