### PR TITLE
Add animated knot model

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It's made with plain new JS.
 - Mouse wheel to zoom in and out.
 - Touch drag to rotate the view.
 - Pinch to zoom in and out on touch screens.
-- Choose between several 3D models like sword, cube, sphere, star, pyramid and the new heart.
+- Choose between several 3D models like sword, cube, sphere, star, pyramid, the new heart and knot.
 - Points and lines are now rendered in proper depth order.
 - Objects behind the camera are never rendered.
 

--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
     <option value="heart">Heart</option>
     <option value="pyramid">Pyramid</option>
     <option value="pendulum">Pendulum</option>
+    <option value="knot">Knot</option>
   </select>
   <div id="stats-overlay" class="hidden"></div>
   <div id="press-hint">Press H for help</div>

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ import { createStar } from './models/star.js';
 import { createHeart } from './models/heart.js';
 import { createPyramid } from './models/pyramid.js';
 import { createPendulum } from './models/pendulum.js';
+import { createKnot } from './models/knot.js';
 
 const RENDER_SCALE = 2; // canvas is scaled up 2x so rendering is at half resolution
 
@@ -258,6 +259,9 @@ const raf = (timestamp) => {
   if (modelSelect.value === 'pendulum') {
     updatePendulum(delta);
   }
+  if (modelSelect.value === 'knot') {
+    updateKnot(delta);
+  }
 
 try {
   C3D.settings.occlusion = enableOcclusion;
@@ -313,6 +317,7 @@ starPoints.forEach(p => p.setColor('#fa0'));
 const { points: heartPoints, lines: heartLines } = createHeart();
 const { points: pyramidPoints, lines: pyramidLines } = createPyramid(2, 2);
 const { points: pendulumPoints, lines: pendulumLines, update: updatePendulum } = createPendulum(4, 1);
+const { points: knotPoints, lines: knotLines, update: updateKnot } = createKnot();
 
 let currentLines = swordLines;
 
@@ -330,6 +335,8 @@ const updateModel = () => {
     currentLines = pyramidLines;
   } else if (value === 'pendulum') {
     currentLines = pendulumLines;
+  } else if (value === 'knot') {
+    currentLines = knotLines;
   } else {
     currentLines = swordLines;
   }

--- a/models/knot.js
+++ b/models/knot.js
@@ -1,0 +1,41 @@
+import Point3D from '../point3d.js';
+
+export function createKnot(p = 2, q = 3, radius = 3, tube = 0.8, segments = 200) {
+  const points = [];
+  const lines = [];
+
+  for (let i = 0; i < segments; i++) {
+    const t = (i / segments) * Math.PI * 2;
+    const x = (radius + tube * Math.cos(q * t)) * Math.cos(p * t);
+    const y = (radius + tube * Math.cos(q * t)) * Math.sin(p * t);
+    const z = tube * Math.sin(q * t);
+    points.push(new Point3D(x, y, z));
+  }
+
+  for (let i = 0; i < segments; i++) {
+    const a = points[i];
+    const b = points[(i + 1) % segments];
+    lines.push([a, b]);
+  }
+
+  points.forEach(p => p.setColor('#0ff'));
+
+  const base = points.map(p => ({ x: p.x, y: p.y, z: p.z }));
+  let rot = 0;
+  const speed = 30; // degrees per second
+
+  const update = (delta) => {
+    rot += speed * delta;
+    const rad = rot * Math.PI / 180;
+    const cos = Math.cos(rad);
+    const sin = Math.sin(rad);
+    for (let i = 0; i < points.length; i++) {
+      const b = base[i];
+      const x = b.x * cos - b.z * sin;
+      const z = b.x * sin + b.z * cos;
+      points[i].setPosition(x, b.y, z);
+    }
+  };
+
+  return { points, lines, update };
+}


### PR DESCRIPTION
## Summary
- add a torus knot model with simple rotation animation
- include the new knot option in the UI and model loader
- update README with the knot model

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b6f7874d8832290f0d55628717081