### PR TITLE
Add point selection list in editor mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,15 @@
       max-height: 40%;
       overflow-y: auto;
     }
+    #points-select {
+      width: 100%;
+      margin-top: 5px;
+      background: rgba(0,0,0,0.7);
+      color: #0f0;
+      border: 1px solid #0f0;
+      font-family: monospace;
+      font-size: 12px;
+    }
     #editor-overlay.hidden { display: none; }
     </style>
     <meta charset="utf-8">
@@ -116,6 +125,7 @@
       <button id="add-point-btn">Add</button>
     </div>
     <ul id="points-list" style="list-style:none;padding:0;margin:0"></ul>
+    <select id="points-select" size="5" style="width:100%;margin-top:5px"></select>
   </div>
   <div id="press-hint">Press H for help</div>
   <script type="module" src="./main.js"></script>

--- a/main.js
+++ b/main.js
@@ -50,6 +50,7 @@ const zInput = document.getElementById('edit-z');
 const colorInput = document.getElementById('edit-color');
 const addPointBtn = document.getElementById('add-point-btn');
 const pointsList = document.getElementById('points-list');
+const pointsSelect = document.getElementById('points-select');
 const urlParams = new URLSearchParams(window.location.search);
 const editorEnabled = urlParams.has('edit');
 let refreshEditorList = () => {};
@@ -57,6 +58,7 @@ if (editorEnabled) {
   editorOverlay.classList.remove('hidden');
   refreshEditorList = () => {
     pointsList.innerHTML = '';
+    pointsSelect.innerHTML = '';
     arr.forEach((p, idx) => {
       const li = document.createElement('li');
       li.textContent = `#${idx} x:${p.x.toFixed(2)} y:${p.y.toFixed(2)} z:${p.z.toFixed(2)} ${p.color}`;
@@ -68,8 +70,23 @@ if (editorEnabled) {
       });
       li.appendChild(btn);
       pointsList.appendChild(li);
+
+      const option = document.createElement('option');
+      option.value = idx;
+      option.textContent = `#${idx}`;
+      pointsSelect.appendChild(option);
     });
   };
+  pointsSelect.addEventListener('change', () => {
+    const idx = parseInt(pointsSelect.value);
+    const p = arr[idx];
+    if (p) {
+      xInput.value = p.x.toFixed(2);
+      yInput.value = p.y.toFixed(2);
+      zInput.value = p.z.toFixed(2);
+      colorInput.value = p.color;
+    }
+  });
   addPointBtn.addEventListener('click', () => {
     const p = new Point3D(
       parseFloat(xInput.value) || 0,


### PR DESCRIPTION
## Summary
- add a `<select>` element to choose points
- list existing points in both the list and dropdown
- update editor inputs when a point is selected

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b9093ce64832291223dae2a76994d