### PR TITLE
Enable editing of points

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,8 @@ It's made with plain new JS.
 - Points and lines are now rendered in proper depth order.
 - Objects behind the camera are never rendered.
 
+## Point Editor
+
+Add `?edit` to the URL to enable the editor overlay. The editor lets you add new points, edit the selected point's position or color, and delete points from the list.
+
 Check it here: [https://rokyed.github.io/canvas-dot/](https://rokyed.github.io/canvas-dot/)

--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
       Z:<input id="edit-z" type="number" step="0.1" style="width:50px">
       <input id="edit-color" type="color" value="#ff0000">
       <button id="add-point-btn">Add</button>
+      <button id="update-point-btn">Update</button>
     </div>
     <ul id="points-list" style="list-style:none;padding:0;margin:0"></ul>
     <select id="points-select" size="5" style="width:100%;margin-top:5px"></select>

--- a/main.js
+++ b/main.js
@@ -49,6 +49,7 @@ const yInput = document.getElementById('edit-y');
 const zInput = document.getElementById('edit-z');
 const colorInput = document.getElementById('edit-color');
 const addPointBtn = document.getElementById('add-point-btn');
+const updatePointBtn = document.getElementById('update-point-btn');
 const pointsList = document.getElementById('points-list');
 const pointsSelect = document.getElementById('points-select');
 const urlParams = new URLSearchParams(window.location.search);
@@ -85,6 +86,20 @@ if (editorEnabled) {
       yInput.value = p.y.toFixed(2);
       zInput.value = p.z.toFixed(2);
       colorInput.value = p.color;
+    }
+  });
+  updatePointBtn.addEventListener('click', () => {
+    const idx = parseInt(pointsSelect.value);
+    const p = arr[idx];
+    if (p) {
+      p.setPosition(
+        parseFloat(xInput.value) || 0,
+        parseFloat(yInput.value) || 0,
+        parseFloat(zInput.value) || 0
+      );
+      p.setColor(colorInput.value);
+      refreshEditorList();
+      pointsSelect.value = idx;
     }
   });
   addPointBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add update button to the editor overlay
- support editing a selected point in the editor
- document how to use the point editor

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b9e20a3c08322b2b490c82ee72961