### PR TITLE
Fix drawStats stroke property

### DIFF
--- a/canvas3d.js
+++ b/canvas3d.js
@@ -268,7 +268,7 @@ export default class Canvas3D {
   drawStats() {
     let size = 10;
     let i = 0;
-    this.ctx.strokeColor = '#0f0';
+    this.ctx.strokeStyle = '#0f0';
     this.ctx.fillStyle = '#0f0';
     this.ctx.font = `bold ${size}px arial`;
     let toDraw = {


### PR DESCRIPTION
## Summary
- fix property name when setting line color in drawStats

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684baf9e5d308322b03ef35f09c6a204