### PR TITLE
Enable touch toggle for draw mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
         R: hardware lines<br>
         M: toggle stats<br>
         F/V: add/remove points<br>
-        Draw Mode button: hold mouse to draw lines<br>
+        Draw Mode button: hold mouse or touch to draw lines<br>
         B: batch points<br>
         O: toggle screen occlusion (default on)<br>
         L: fullscreen<br>

--- a/main.js
+++ b/main.js
@@ -257,7 +257,7 @@ document.addEventListener('wheel', (e) => {
 }, { passive: false });
 
 document.addEventListener('touchstart', (e) => {
-  if (e.target.closest('#model-select')) return;
+  if (e.target.closest('#model-select') || e.target.closest('#draw-toggle')) return;
   if (drawMode) {
     if (e.touches.length === 1) {
       drawing = true;
@@ -284,7 +284,7 @@ document.addEventListener('touchstart', (e) => {
 }, { passive: false });
 
 document.addEventListener('touchmove', (e) => {
-  if (e.target.closest('#model-select')) return;
+  if (e.target.closest('#model-select') || e.target.closest('#draw-toggle')) return;
   if (drawMode) {
     if (drawing && e.touches.length === 1) {
       const touch = e.touches[0];
@@ -315,7 +315,7 @@ document.addEventListener('touchmove', (e) => {
 }, { passive: false });
 
 document.addEventListener('touchend', (e) => {
-  if (e.target.closest('#model-select')) return;
+  if (e.target.closest('#model-select') || e.target.closest('#draw-toggle')) return;
   if (drawMode) {
     if (e.touches.length === 0) {
       drawing = false;
@@ -333,7 +333,7 @@ document.addEventListener('touchend', (e) => {
 }, { passive: false });
 
 document.addEventListener('touchcancel', (e) => {
-  if (e.target.closest('#model-select')) return;
+  if (e.target.closest('#model-select') || e.target.closest('#draw-toggle')) return;
   if (drawMode) {
     drawing = false;
     currentLine = null;


### PR DESCRIPTION
## Summary
- allow draw mode toggle button to receive touch input
- update help overlay text for drawing with touch

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dfe9702648322af4dbd75f8c2534f